### PR TITLE
fix: Bump Prospector to 1.3.1 on the json to match the requirements CY-3802

### DIFF
--- a/docs/patterns.json
+++ b/docs/patterns.json
@@ -1,6 +1,6 @@
 {
   "name": "prospector",
-  "version": "1.2.0",
+  "version": "1.3.1",
   "patterns": [
     {
       "patternId": "pylint",


### PR DESCRIPTION
This way matches the version at https://github.com/codacy/codacy-prospector/blob/master/requirements.txt#L2

It would be cool to be able to change the version only in 1 place. I assume that the tasks with the automated generation will tackle that when tackled.