### PR TITLE
fix: Skip `import-error`s from Pylint CY-3864

### DIFF
--- a/docs/multiple-tests/skip-import-error/results.xml
+++ b/docs/multiple-tests/skip-import-error/results.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<checkstyle version="4.3">
+    <file name="test.py">
+        <error source="pylint" line="1" message="Unused import requests (unused-import)" severity="info" />
+    </file>
+</checkstyle>

--- a/docs/multiple-tests/skip-import-error/src/test.py
+++ b/docs/multiple-tests/skip-import-error/src/test.py
@@ -1,0 +1,1 @@
+import requests

--- a/src/codacy_prospector.py
+++ b/src/codacy_prospector.py
@@ -74,7 +74,7 @@ def parseResult(json_text):
     messages = json.loads(json_text)["messages"]
     def createResults():
         for res in messages:
-            if res['code'] != 'failure':
+            if res['code'] != 'failure' and res['code'] != 'import-error':
                 location = res['location']
                 yield Result(filename=location['path'], message=f"{res['message']} ({res['code']})", patternId=res['source'], line=location['line'])
     return list(createResults())


### PR DESCRIPTION
Both [codacy-pylint](https://github.com/codacy/codacy-pylint) and [codacy-pylint-python3](https://github.com/codacy/codacy-pylint-python3) solved this problem already: here https://github.com/codacy/codacy-pylint-python3/pull/59 and here https://github.com/codacy/codacy-pylint/pull/63 .
The solution, however, was never ported to Prospector

This should solve the problem in #57 