### PR TITLE
doc: Use American English spelling "analyzing" on tool description DOCS-319

### DIFF
--- a/docs/tool-description.md
+++ b/docs/tool-description.md
@@ -1,3 +1,3 @@
-Prospector is a tool to analyse Python code and output information about errors, potential problems, convention violations and complexity.
+Prospector is a tool to analyze Python code and output information about errors, potential problems, convention violations and complexity.
 
 It brings together the functionality of other Python analysis tools such as [Pylint](https://pylint.readthedocs.io/), [pep8](https://pep8.readthedocs.io/), and [McCabe complexity](https://pypi.python.org/pypi/mccabe).


### PR DESCRIPTION
When making [this change](https://github.com/codacy/codacy-spa/pull/683) on codacy-spa I updated the description of the tools in the tests but forgot to update the actual tools themselves.

Related pull requests:

* https://github.com/codacy/codacy-sonar-visual-basic/pull/75
* https://github.com/codacy/codacy-sonar-csharp/pull/130