### PR TITLE
feature: Return sourceId CF-1827

### DIFF
--- a/src/codacy_prospector.py
+++ b/src/codacy_prospector.py
@@ -26,17 +26,18 @@ def getTimeout(timeoutString):
     return int(timeoutString)
 
 class Result:
-    def __init__(self, filename, message, patternId, line):
+    def __init__(self, filename, message, patternId, line, sourceId):
         self.filename = filename
         self.message = message
         self.patternId = patternId
         self.line = line
+        self.sourceId = sourceId
     def __str__(self):
-        return f'Result({self.filename},{self.message},{self.patternId},{self.line})'
+        return f'Result({self.filename},{self.message},{self.patternId},{self.line},{self.sourceId})'
     def __repr__(self):
         return self.__str__()
     def __eq__(self, o):
-        return self.filename == o.filename and self.message == o.message and self.patternId == o.patternId and self.line == o.line
+        return self.filename == o.filename and self.message == o.message and self.patternId == o.patternId and self.line == o.line and self.sourceId == o.sourceId
 
 def toJson(obj): return jsonpickle.encode(obj, unpicklable=False)
 
@@ -78,7 +79,7 @@ def parseResult(json_text):
         for res in messages:
             if res['code'] != 'failure' and res['code'] != 'import-error':
                 location = res['location']
-                yield Result(filename=location['path'], message=f"{res['message']} ({res['code']})", patternId=res['source'], line=location['line'])
+                yield Result(filename=location['path'], message=f"{res['message']} ({res['code']})", patternId=res['source'], line=location['line'], sourceId=res['code'])
     return list(createResults())
 
 def walkDirectory(directory):

--- a/src/codacy_prospector_test.py
+++ b/src/codacy_prospector_test.py
@@ -42,9 +42,9 @@ def dup_function():
 
 class ResultTest(unittest.TestCase):
     def test_toJson(self):
-        result = Result("file.py", "message", "id", 80)
+        result = Result("file.py", "message", "id", 80, "E0102")
         res = toJson(result)
-        expected = '{"filename": "file.py", "message": "message", "patternId": "id", "line": 80}'
+        expected = '{"filename": "file.py", "message": "message", "patternId": "id", "line": 80, "sourceId": "E0102"}'
         self.assertEqual(res, expected)
 
 class ProspectorTest(unittest.TestCase):


### PR DESCRIPTION
- [x] test it manually

Building locally and trying `multiple-tests/with-config-file`, LGTM:

`docker run -v $(pwd):/src prospector-local:latest`
```
{"filename": "example.py", "message": "Multi-line docstring summary should start at the first line (D212)", "patternId": "pydocstyle", "line": 1, "sourceId": "D212"}
{"filename": "example.py", "message": "No value for argument 'on_delete' in constructor call (no-value-for-parameter)", "patternId": "pylint", "line": 99, "sourceId": "no-value-for-parameter"}
{"filename": "example.py", "message": "No value for argument 'on_delete' in constructor call (no-value-for-parameter)", "patternId": "pylint", "line": 100, "sourceId": "no-value-for-parameter"}
{"filename": "example.py", "message": "No value for argument 'on_delete' in constructor call (no-value-for-parameter)", "patternId": "pylint", "line": 114, "sourceId": "no-value-for-parameter"}
{"filename": "example.py", "message": "No value for argument 'on_delete' in constructor call (no-value-for-parameter)", "patternId": "pylint", "line": 125, "sourceId": "no-value-for-parameter"}
```